### PR TITLE
Use new Database environment variables for v13.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,23 @@ dokku apps:create grafana
     dokku config grafana
     ```
 
-2. Set the `GF_DATABASE_URL` environment variable:
+    The database URL should follow the format:
 
     ```bash
-    dokku config:set grafana GF_DATABASE_URL='previously_copied_database_url'
+    postgres://<DATABASE_USER>:<DATABASE_PASSWORD>@<DATABASE_HOST>:<DATABASE_PORT>/<DATABASE_NAME>
+    ```
+
+
+2. Set the `GF_DATABASE_*` environment variables:
+
+    ```bash
+    dokku config:set grafana \
+      GF_DATABASE_TYPE=postgres \
+      GF_DATABASE_URL='<DATABASE_URL>' \
+      GF_DATABASE_HOST='<DATABASE_HOST>:<DATABASE_PORT>' \
+      GF_DATABASE_NAME=<DATABASE_NAME> \
+      GF_DATABASE_USER=<DATABASE_USER> \
+      GF_DATABASE_PASSWORD=<DATABASE_PASSWORD>
     ```
 
 3. Set the HTTP port for Grafana:


### PR DESCRIPTION
Hi. It looks like the latest version of Grafana now requires a `GF_DATABASE_TYPE` environment variable. Without it, I found that the installation would default to using an sqlite3 database.

I believe the old `GF_DATABASE_URL` variable now has to be split into parts as well